### PR TITLE
Pause between WA version installs to allow user to initialize WA.

### DIFF
--- a/WhatsAppKeyDBExtract.bat
+++ b/WhatsAppKeyDBExtract.bat
@@ -103,9 +103,9 @@ bin\adb.exe install -r -d tmp\LegacyWhatsApp.apk
 ) else (
 bin\adb.exe install -r tmp\LegacyWhatsApp.apk
 )
-echo Install complete
+echo Install complete! Open Whatsapp, allow the permissions request, if any. Then, press Enter to continue.
 echo.
-set /p trashvar="Paused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue."
+set /p paused=
 echo.
 if %sdkver% geq 23 (
 bin\adb.exe backup -f tmp\whatsapp.ab com.whatsapp

--- a/WhatsAppKeyDBExtract.bat
+++ b/WhatsAppKeyDBExtract.bat
@@ -105,6 +105,8 @@ bin\adb.exe install -r tmp\LegacyWhatsApp.apk
 )
 echo Install complete
 echo.
+set /p trashvar="Paused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue."
+echo.
 if %sdkver% geq 23 (
 bin\adb.exe backup -f tmp\whatsapp.ab com.whatsapp
 ) else (

--- a/WhatsAppKeyDBExtract.ps1
+++ b/WhatsAppKeyDBExtract.ps1
@@ -84,13 +84,15 @@ Invoke-Expression "bin\adb.exe install -r -d tmp\LegacyWhatsApp.apk"
 Invoke-Expression "bin\adb.exe install -r tmp\LegacyWhatsApp.apk"
 }
 "Install complete`r`n"
+""
+$trashvar = Read-Host 'Paused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue'
+""
 If ($sdkver -ge 23)
 {
 Invoke-Expression "bin\adb.exe backup -f tmp\whatsapp.ab com.whatsapp"
 } Else {
 Invoke-Expression "bin\adb.exe backup -f tmp\whatsapp.ab -noapk com.whatsapp"
 }
-
 If (Test-Path "tmp\whatsapp.ab")
 {
 ""

--- a/WhatsAppKeyDBExtract.ps1
+++ b/WhatsAppKeyDBExtract.ps1
@@ -83,9 +83,9 @@ Invoke-Expression "bin\adb.exe install -r -d tmp\LegacyWhatsApp.apk"
 } Else {
 Invoke-Expression "bin\adb.exe install -r tmp\LegacyWhatsApp.apk"
 }
-"Install complete`r`n"
+"Install complete! Open Whatsapp, allow the permissions request, if any. Then, press Enter to continue.`r`n"
 ""
-$trashvar = Read-Host 'Paused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue'
+$paused = Read-Host
 ""
 If ($sdkver -ge 23)
 {

--- a/WhatsAppKeyDBExtract.sh
+++ b/WhatsAppKeyDBExtract.sh
@@ -87,6 +87,7 @@ else
 adb install -r tmp/LegacyWhatsApp.apk
 fi
 echo -e "Install complete\n"
+echo -e "\nPaused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue"; read trashvar
 if [ $sdkver -ge 23 ]; then
 adb backup -f tmp/whatsapp.ab com.whatsapp
 else

--- a/WhatsAppKeyDBExtract.sh
+++ b/WhatsAppKeyDBExtract.sh
@@ -86,8 +86,8 @@ adb install -r -d tmp/LegacyWhatsApp.apk
 else
 adb install -r tmp/LegacyWhatsApp.apk
 fi
-echo -e "Install complete\n"
-echo -e "\nPaused. Open Whatsapp. Ok the Permissions Request. Press Enter to continue"; read trashvar
+echo -e "Install complete! Open Whatsapp, allow the permissions request, if any. Then, press Enter to continue.\n"
+read paused
 if [ $sdkver -ge 23 ]; then
 adb backup -f tmp/whatsapp.ab com.whatsapp
 else


### PR DESCRIPTION
Issue #4 
Some version of Android devices seem to halt on the 'Request Permissions' and dont create the folder structure until this is confirmed and the app is officially opened. This should alert the user and allow for manual intervention on those versions that need it.

I've altered the Linux/Mac Shellscript with the pause and instruction to tell the user to interact with the phone as required. Ive also tried my hand at the Powershell and Batch scripts but need a review in that PR. 